### PR TITLE
Alternative script setup and logger interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,4 @@ typings/
 .next
 
 # build directory
-build
+dist

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,8 @@
 {
-  "recommendations": ["orta.vscode-jest"],
+  "recommendations": [
+    "orta.vscode-jest",
+    "esbenp.prettier-vscode",
+    "ms-vscode.vscode-typescript-tslint-plugin"
+  ],
   "unwantedRecommendations": []
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,10 @@
 module.exports = {
-  testRegex: '.test.ts$|.spec.ts$',
+  testRegex: '.(test|spec).(j|t)s$',
   transform: {
     '^.+\\.(t|j)s$': 'ts-jest',
   },
-  collectCoverageFrom: ['<rootDir>/src/*/**/*.ts', '!<rootDir>/src/index.ts'],
+  collectCoverageFrom: ['<rootDir>/src/**/*.ts', '!<rootDir>/src/run.ts'],
   testEnvironment: 'node',
   resetMocks: true,
-  coverageReporters: ['json-summary'],
+  coverageReporters: ['json-summary', 'text'],
 };

--- a/package.json
+++ b/package.json
@@ -2,25 +2,22 @@
   "name": "node-gts-jest-boilerplate",
   "version": "1.0.0",
   "description": "",
-  "main": "build/src/index.js",
-  "types": "build/src/index.d.ts",
+  "main": "dist/main.js",
+  "types": "dist/main.d.ts",
   "files": [
-    "build/src"
+    "dist/src"
   ],
   "license": "MIT",
   "keywords": [],
   "scripts": {
-    "start": "npm run compile:prod && node build/src/index.js",
-    "test": "jest --coverage --passWithNoTests",
-    "debug": "node --nolazy --inspect-brk=9339 build/src/index.js",
-    "check": "gts check",
-    "clean": "gts clean",
-    "compile": "tsc -p .",
-    "compile:prod": "tsc -p tsconfig.prod.json",
-    "fix": "gts fix",
-    "prepare": "npm run compile",
-    "pretest": "npm run compile",
-    "posttest": "npm run check"
+    "start": "scripts/start",
+    "test": "scripts/test",
+    "debug": "scripts/start --debug",
+    "check": "scripts/lint",
+    "clean": "scripts/clean",
+    "compile": "scripts/build",
+    "compile:prod": "scripts/build --prod",
+    "fix": "scripts/lint-fix"
   },
   "devDependencies": {
     "@types/jest": "^24.0.22",

--- a/run
+++ b/run
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Generic script runner
+
+set -e
+cd "$(dirname $0)";
+
+case $1 in
+  bootstrap)
+    scripts/bootstrap ;;
+  build)
+    scripts/build ;;
+  build-prod)
+    scripts/build --prod ;;
+  clean)
+    scripts/clean ;;
+  debug)
+    scripts/start --debug ;;
+  lint)
+    scripts/lint ;;
+  lint-fix)
+    scripts/lint-fix ;;
+  start)
+    scripts/start ;;
+  start-prod)
+    scripts/start-prod ;;
+  test)
+    scripts/test ;;
+  *)
+    echo "Usage: ./run <command>"
+    echo ""
+    echo "Valid commands:"
+    echo "  bootstrap ....... installs packages"
+    echo "  build ........... compiles application"
+    echo "  build-prod ...... compiles applcation for production"
+    echo "  clean ........... removes build artifacts"
+    echo "  debug ........... start the application in debug mode"
+    echo "  lint ............ checks code for style violations"
+    echo "  lint-fix ........ automtically fixes lint errors if possible"
+    echo "  start ........... start the application"
+    echo "  start-prod ...... start the application in production mode"
+    echo "  test ............ runs tests"
+esac

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Run this script immediately after cloning the repository
+
+set -e
+cd "$(dirname $0)"; cd ..
+
+npm install

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Use this script to build the application
+# Run "build --prod" to build for production
+
+set -e
+cd "$(dirname $0)"; cd ..
+
+scripts/clean
+echo ""
+
+if [ "$1" = "--prod" ]
+then
+  scripts/test
+  echo ""
+
+  echo "> tsc -p tsconfig.prod.json"
+  node_modules/.bin/tsc -p tsconfig.prod.json  
+else
+  echo "> tsc -p ."
+  node_modules/.bin/tsc -p .
+fi

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Use this script to remove compiled code and other artifacts
+
+set -e
+cd "$(dirname $0)"; cd ..
+
+echo "> rm -rf dist"
+rm -rf dist

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Run this script to check for linting errors
+
+set -e
+cd "$(dirname $0)"; cd ..
+
+echo "> gts check"
+node_modules/.bin/gts check

--- a/scripts/lint-fix
+++ b/scripts/lint-fix
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Run this script to fix lint errors if possible
+
+set -e
+cd "$(dirname $0)"; cd ..
+
+echo "> gts fix"
+node_modules/.bin/gts fix

--- a/scripts/start
+++ b/scripts/start
@@ -13,12 +13,12 @@ fi
 
 echo ""
 
-if $ok && [ "$1" = "--debug" ]
+if [ "$1" = "--debug" ]
 then
-  echo "> node --nolazy --inspect-brk=9339 dist/index.js"
-  node --nolazy --inspect-brk=9339 dist/index.js
+  echo "> node --nolazy --inspect-brk=9339 dist/run.js"
+  node --nolazy --inspect-brk=9339 dist/run.js
 else
-  echo "> node dist/index.js"
-  node dist/index.js
+  echo "> node dist/run.js"
+  node dist/run.js
 fi
 

--- a/scripts/start
+++ b/scripts/start
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Run this stript to start the application.
+
+set -e
+cd "$(dirname $0)"; cd ..
+
+if [ "$1" = "--prod" ]
+then
+  scripts/build --prod
+else
+  scripts/build
+fi
+
+echo ""
+
+if $ok && [ "$1" = "--debug" ]
+then
+  echo "> node --nolazy --inspect-brk=9339 dist/index.js"
+  node --nolazy --inspect-brk=9339 dist/index.js
+else
+  echo "> node dist/index.js"
+  node dist/index.js
+fi
+

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Use this script to run unit tests and linting
+
+set -e
+cd "$(dirname $0)"; cd ..
+
+echo "> jest --coverage"
+node_modules/.bin/jest --coverage
+
+echo ""
+scripts/lint

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-console.log('Project executed.');
+export * from './main';
+export * from './main.models';

--- a/src/main.models.ts
+++ b/src/main.models.ts
@@ -1,0 +1,5 @@
+import { Logger } from './util';
+
+export interface ApplicationDependencies {
+  logger?: Logger;
+}

--- a/src/main.spec.ts
+++ b/src/main.spec.ts
@@ -1,0 +1,27 @@
+import { Main } from '.';
+
+describe('Main', () => {
+  const mockLogger = {
+    emergency: jest.fn(),
+    alert: jest.fn(),
+    critical: jest.fn(),
+    error: jest.fn(),
+    warning: jest.fn(),
+    notice: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  };
+
+  it('should construct itself', () => {
+    const target = new Main();
+    expect(target.constructor.name).toBe('Main');
+  });
+
+  describe('runOnce', () => {
+    it('should log that it has started', async () => {
+      const target = new Main({ logger: mockLogger });
+      await target.runOnce();
+      expect(mockLogger.notice).toHaveBeenCalledWith('Started');
+    });
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,15 @@
+import { ApplicationDependencies } from './main.models';
+import { Logger, ConsoleLogger } from './util';
+
+export class Main {
+  private readonly logger: Logger;
+
+  constructor(dependencies: ApplicationDependencies = {}) {
+    this.logger = dependencies.logger || new ConsoleLogger();
+  }
+
+  runOnce() {
+    this.logger.notice('Started');
+    return Promise.resolve();
+  }
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,14 @@
+import { Main } from '.';
+import { ConsoleLogger } from './util';
+
+const application = new Main();
+const logger = new ConsoleLogger();
+
+application
+  .runOnce()
+  .then(() => {
+    logger.notice('Done');
+  })
+  .catch(e => {
+    logger.error('Something went wrong', e);
+  });

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,1 @@
+export * from './logger';

--- a/src/util/interfaces.ts
+++ b/src/util/interfaces.ts
@@ -1,0 +1,3 @@
+export interface Dictionary<T> {
+  [key: string]: T;
+}

--- a/src/util/logger/console-logger/console-logger.models.ts
+++ b/src/util/logger/console-logger/console-logger.models.ts
@@ -1,0 +1,7 @@
+export interface ConsoleLoggingInterface {
+  error: (message: string) => void;
+  warn: (message: string) => void;
+  log: (message: string) => void;
+  info: (message: string) => void;
+  debug: (message: string) => void;
+}

--- a/src/util/logger/console-logger/console-logger.spec.ts
+++ b/src/util/logger/console-logger/console-logger.spec.ts
@@ -1,0 +1,260 @@
+import { ConsoleLogger, LogLevel } from '..';
+import { LoggerUtil } from '../logger-util';
+import { expectDate } from '../../../../test/util';
+
+describe('ConsoleLogger', () => {
+  const defaultLogLevel = LogLevel.INFO;
+  const testMessage = 'testing 123';
+  const testError = Error('I accidentally an error');
+  const testData = { additionalInfo: 'I like turtles' };
+
+  const consoleLoggerInterface = {
+    error: jest.fn(),
+    warn: jest.fn(),
+    log: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  };
+
+  const allLogLevels = [
+    LogLevel.EMERG,
+    LogLevel.ALERT,
+    LogLevel.CRIT,
+    LogLevel.ERROR,
+    LogLevel.WARN,
+    LogLevel.NOTICE,
+    LogLevel.INFO,
+    LogLevel.DEBUG,
+  ];
+
+  const getMessageContent = (logEntry: string) =>
+    logEntry
+      .split(' ')
+      .slice(1)
+      .join(' ');
+
+  const getLoggedMessageContent = (mockFn: jest.Mock) =>
+    getMessageContent(mockFn.mock.calls[0][0]);
+
+  const checkThatNoLogsAreMade = () => {
+    expect(consoleLoggerInterface.error.mock.calls).toEqual([]);
+    expect(consoleLoggerInterface.warn.mock.calls).toEqual([]);
+    expect(consoleLoggerInterface.log.mock.calls).toEqual([]);
+    expect(consoleLoggerInterface.info.mock.calls).toEqual([]);
+    expect(consoleLoggerInterface.debug.mock.calls).toEqual([]);
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('sets uses the default log level by default', () => {
+    const target = new ConsoleLogger();
+    expect(target.logLevel).toBe(defaultLogLevel);
+  });
+
+  it('sets a custom log level if provided', () => {
+    const target = new ConsoleLogger(LogLevel.ERROR);
+    expect(target.logLevel).toBe(LogLevel.ERROR);
+  });
+
+  describe('emergency', () => {
+    const expectedLogContent = getMessageContent(
+      LoggerUtil.createLogEntry(LogLevel.EMERG, testMessage, testError)
+    );
+
+    it('calls console.error with expected message content at all log levels', () => {
+      allLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.emergency(testMessage, testError);
+        const logContent = getLoggedMessageContent(
+          consoleLoggerInterface.error
+        );
+        expect(logContent).toBe(expectedLogContent);
+      });
+    });
+  });
+
+  describe('alert', () => {
+    const inactiveLogLevels = allLogLevels.slice(0, LogLevel.ALERT);
+    const activeLogLevels = allLogLevels.slice(LogLevel.ALERT);
+    const expectedLogContent = getMessageContent(
+      LoggerUtil.createLogEntry(LogLevel.ALERT, testMessage, testError)
+    );
+
+    it('calls console.error with expected message content at all active log levels', () => {
+      activeLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.alert(testMessage, testError);
+        const logContent = getLoggedMessageContent(
+          consoleLoggerInterface.error
+        );
+        expect(logContent).toBe(expectedLogContent);
+      });
+    });
+
+    it('does nothing for all incative log levels', () => {
+      inactiveLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.alert(testMessage, testError);
+        checkThatNoLogsAreMade();
+      });
+    });
+  });
+
+  describe('critical', () => {
+    const inactiveLogLevels = allLogLevels.slice(0, LogLevel.CRIT);
+    const activeLogLevels = allLogLevels.slice(LogLevel.CRIT);
+    const expectedLogContent = getMessageContent(
+      LoggerUtil.createLogEntry(LogLevel.CRIT, testMessage, testError)
+    );
+
+    it('calls console.error with expected message content at all active log levels', () => {
+      activeLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.critical(testMessage, testError);
+        const logContent = getLoggedMessageContent(
+          consoleLoggerInterface.error
+        );
+        expect(logContent).toBe(expectedLogContent);
+      });
+    });
+
+    it('does nothing for all incative log levels', () => {
+      inactiveLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.critical(testMessage, testError);
+        checkThatNoLogsAreMade();
+      });
+    });
+  });
+
+  describe('error', () => {
+    const inactiveLogLevels = allLogLevels.slice(0, LogLevel.ERROR);
+    const activeLogLevels = allLogLevels.slice(LogLevel.ERROR);
+    const expectedLogContent = getMessageContent(
+      LoggerUtil.createLogEntry(LogLevel.ERROR, testMessage, testError)
+    );
+
+    it('calls console.error with expected message content at all active log levels', () => {
+      activeLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.error(testMessage, testError);
+        const logContent = getLoggedMessageContent(
+          consoleLoggerInterface.error
+        );
+        expect(logContent).toBe(expectedLogContent);
+      });
+    });
+
+    it('does nothing for all incative log levels', () => {
+      inactiveLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.error(testMessage, testError);
+        checkThatNoLogsAreMade();
+      });
+    });
+  });
+
+  describe('warning', () => {
+    const inactiveLogLevels = allLogLevels.slice(0, LogLevel.WARN);
+    const activeLogLevels = allLogLevels.slice(LogLevel.WARN);
+    const expectedLogContent = getMessageContent(
+      LoggerUtil.createLogEntry(LogLevel.WARN, testMessage)
+    );
+
+    it('calls console.error with expected message content at all active log levels', () => {
+      activeLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.warning(testMessage);
+        const logContent = getLoggedMessageContent(consoleLoggerInterface.warn);
+        expect(logContent).toBe(expectedLogContent);
+      });
+    });
+
+    it('does nothing for all incative log levels', () => {
+      inactiveLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.warning(testMessage);
+        checkThatNoLogsAreMade();
+      });
+    });
+  });
+
+  describe('notice', () => {
+    const inactiveLogLevels = allLogLevels.slice(0, LogLevel.NOTICE);
+    const activeLogLevels = allLogLevels.slice(LogLevel.NOTICE);
+    const expectedLogContent = getMessageContent(
+      LoggerUtil.createLogEntry(LogLevel.NOTICE, testMessage)
+    );
+
+    it('calls console.error with expected message content at all active log levels', () => {
+      activeLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.notice(testMessage);
+        const logContent = getLoggedMessageContent(consoleLoggerInterface.log);
+        expect(logContent).toBe(expectedLogContent);
+      });
+    });
+
+    it('does nothing for all incative log levels', () => {
+      inactiveLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.notice(testMessage);
+        checkThatNoLogsAreMade();
+      });
+    });
+  });
+
+  describe('info', () => {
+    const inactiveLogLevels = allLogLevels.slice(0, LogLevel.INFO);
+    const activeLogLevels = allLogLevels.slice(LogLevel.INFO);
+    const expectedLogContent = getMessageContent(
+      LoggerUtil.createLogEntry(LogLevel.INFO, testMessage, testData)
+    );
+
+    it('calls console.error with expected message content at all active log levels', () => {
+      activeLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.info(testMessage, testData);
+        const logContent = getLoggedMessageContent(consoleLoggerInterface.info);
+        expect(logContent).toBe(expectedLogContent);
+      });
+    });
+
+    it('does nothing for all incative log levels', () => {
+      inactiveLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.info(testMessage, testData);
+        checkThatNoLogsAreMade();
+      });
+    });
+  });
+
+  describe('debug', () => {
+    const inactiveLogLevels = allLogLevels.slice(0, LogLevel.DEBUG);
+    const activeLogLevels = allLogLevels.slice(LogLevel.DEBUG);
+    const expectedLogContent = getMessageContent(
+      LoggerUtil.createLogEntry(LogLevel.DEBUG, testMessage, testData)
+    );
+
+    it('calls console.error with expected message content at all active log levels', () => {
+      activeLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.debug(testMessage, testData);
+        const logContent = getLoggedMessageContent(
+          consoleLoggerInterface.debug
+        );
+        expect(logContent).toBe(expectedLogContent);
+      });
+    });
+
+    it('does nothing for all incative log levels', () => {
+      inactiveLogLevels.forEach(ll => {
+        const target = new ConsoleLogger(ll, consoleLoggerInterface);
+        target.debug(testMessage, testData);
+        checkThatNoLogsAreMade();
+      });
+    });
+  });
+});

--- a/src/util/logger/console-logger/console-logger.ts
+++ b/src/util/logger/console-logger/console-logger.ts
@@ -1,0 +1,83 @@
+import { Logger, LogLevel } from '..';
+import { LoggerUtil } from '../logger-util';
+import { ConsoleLoggingInterface } from './console-logger.models';
+
+// tslint:disable: no-any
+export class ConsoleLogger implements Logger {
+  private readonly console: ConsoleLoggingInterface;
+
+  constructor(
+    public logLevel = LogLevel.INFO,
+    customLoggingInterface?: ConsoleLoggingInterface
+  ) {
+    this.console = customLoggingInterface || {
+      error: console.error,
+      warn: console.warn,
+      log: console.log,
+      info: console.info,
+      debug: console.debug,
+    };
+  }
+
+  emergency(message: string, data?: any) {
+    const logEntry = LoggerUtil.createLogEntry(LogLevel.EMERG, message, data);
+    this.console.error(logEntry);
+  }
+
+  alert(message: string, data?: any) {
+    if (this.isLoggable(LogLevel.ALERT)) {
+      const logEntry = LoggerUtil.createLogEntry(LogLevel.ALERT, message, data);
+      this.console.error(logEntry);
+    }
+  }
+
+  critical(message: string, data?: any) {
+    if (this.isLoggable(LogLevel.CRIT)) {
+      const logEntry = LoggerUtil.createLogEntry(LogLevel.CRIT, message, data);
+      this.console.error(logEntry);
+    }
+  }
+
+  error(message: string, data?: any) {
+    if (this.isLoggable(LogLevel.ERROR)) {
+      const logEntry = LoggerUtil.createLogEntry(LogLevel.ERROR, message, data);
+      this.console.error(logEntry);
+    }
+  }
+
+  warning(message: string, data?: any) {
+    if (this.isLoggable(LogLevel.WARN)) {
+      const logEntry = LoggerUtil.createLogEntry(LogLevel.WARN, message, data);
+      this.console.warn(logEntry);
+    }
+  }
+
+  notice(message: string, data?: any) {
+    if (this.isLoggable(LogLevel.NOTICE)) {
+      const logEntry = LoggerUtil.createLogEntry(
+        LogLevel.NOTICE,
+        message,
+        data
+      );
+      this.console.log(logEntry);
+    }
+  }
+
+  info(message: string, data?: any) {
+    if (this.isLoggable(LogLevel.INFO)) {
+      const logEntry = LoggerUtil.createLogEntry(LogLevel.INFO, message, data);
+      this.console.info(logEntry);
+    }
+  }
+
+  debug(message: string, data?: any) {
+    if (this.isLoggable(LogLevel.DEBUG)) {
+      const logEntry = LoggerUtil.createLogEntry(LogLevel.DEBUG, message, data);
+      this.console.debug(logEntry);
+    }
+  }
+
+  private isLoggable(logLevel: LogLevel) {
+    return logLevel <= this.logLevel;
+  }
+}

--- a/src/util/logger/index.ts
+++ b/src/util/logger/index.ts
@@ -1,0 +1,2 @@
+export * from './logger.interface';
+export * from './console-logger/console-logger';

--- a/src/util/logger/logger-util.spec.ts
+++ b/src/util/logger/logger-util.spec.ts
@@ -1,0 +1,90 @@
+import { LoggerUtil } from './logger-util';
+import { LogLevel, LOG_LEVEL_STRINGS } from './logger.interface';
+import { EnvironmentEditor } from '../../../test/util';
+import { expectDate, expectString } from '../../../test/util';
+
+describe('LoggerUtil', () => {
+  const target = LoggerUtil;
+  const testMessage = 'msg';
+  const testError = TypeError('bad type');
+  const testData = { data: {} };
+
+  describe('createLogEntry', () => {
+    it('should include the timestamp at the start', () => {
+      const before = Date.now();
+      const result = target.createLogEntry(LogLevel.INFO, testMessage);
+      const after = Date.now();
+      const timestamp = result.split(' ')[0];
+      expectDate(timestamp).toBeBetween(before, after);
+    });
+
+    it('should include the message at the end if no other data provided', () => {
+      const result = target.createLogEntry(LogLevel.INFO, testMessage);
+      expectString(result).toEndWith(testMessage);
+    });
+
+    it('should include the message if additional data provided', () => {
+      const result = target.createLogEntry(
+        LogLevel.INFO,
+        testMessage,
+        testData
+      );
+      expectString(result).toContain(testMessage);
+    });
+
+    it('should include the log level if additional data provided', () => {
+      const result = target.createLogEntry(
+        LogLevel.WARN,
+        testMessage,
+        testData
+      );
+      expectString(result).toContain(LOG_LEVEL_STRINGS[LogLevel.WARN]);
+    });
+
+    it('should include end with the strigified data object, if provided', () => {
+      const result = target.createLogEntry(
+        LogLevel.INFO,
+        testMessage,
+        testData
+      );
+      expectString(result).toEndWith(JSON.stringify(testData));
+    });
+
+    it('should end with the error stack if provided', () => {
+      const result = target.createLogEntry(
+        LogLevel.INFO,
+        testMessage,
+        testError
+      );
+
+      if (testError.stack) {
+        expectString(result).toEndWith(testError.stack);
+      }
+    });
+  });
+
+  describe('getCurrentLogLevelFromEnv', () => {
+    const envEditor = new EnvironmentEditor();
+    const logLevelKey = 'LOG_LEVEL';
+    const defaultLevel = LogLevel.INFO;
+
+    afterEach(() => {
+      envEditor.resetAll();
+    });
+
+    it('should return the default logging level if the env variable is unset', () => {
+      envEditor.clear(logLevelKey);
+      expect(target.getCurrentLogLevelFromEnv(defaultLevel)).toBe(defaultLevel);
+    });
+
+    it('should return all the valid log levels accorind to their defined order', () => {
+      LOG_LEVEL_STRINGS.forEach((logLevelString, index) => {
+        envEditor.set(logLevelKey, logLevelString);
+        expect(target.getCurrentLogLevelFromEnv(defaultLevel)).toBe(index);
+      });
+
+      envEditor.clear(logLevelKey);
+      expect(target.getCurrentLogLevelFromEnv(defaultLevel)).toBe(defaultLevel);
+    });
+  });
+});

--- a/src/util/logger/logger-util.ts
+++ b/src/util/logger/logger-util.ts
@@ -1,0 +1,42 @@
+import {
+  LogLevel,
+  LOG_LEVEL_STRINGS,
+  LOG_LEVEL_DICTIONARY,
+} from './logger.interface';
+
+// tslint:disable: no-any
+export class LoggerUtil {
+  static createLogEntry(
+    logLevel: LogLevel,
+    message: string,
+    data?: any
+  ): string {
+    const messageLine = `${new Date().toISOString()} [${this.stringifyLogLevel(
+      logLevel
+    )}] ${message}`;
+
+    if (data === undefined) {
+      return messageLine;
+    } else {
+      return `${messageLine}\n${this.stringifyDataOrError(data)}`;
+    }
+  }
+
+  static stringifyDataOrError(data: any): string | undefined {
+    return this.isError(data) ? data.stack : `Data: ${JSON.stringify(data)}`;
+  }
+
+  static isError(data: any): boolean {
+    return data && typeof data.stack === 'string';
+  }
+
+  static stringifyLogLevel(logLevel: LogLevel) {
+    return LOG_LEVEL_STRINGS[logLevel];
+  }
+
+  static getCurrentLogLevelFromEnv(defaultLevel: LogLevel) {
+    return process.env.LOG_LEVEL
+      ? LOG_LEVEL_DICTIONARY[process.env.LOG_LEVEL.toUpperCase()]
+      : defaultLevel;
+  }
+}

--- a/src/util/logger/logger.interface.ts
+++ b/src/util/logger/logger.interface.ts
@@ -1,0 +1,54 @@
+import { Dictionary } from '../interfaces';
+
+// tslint:disable: no-any
+export interface Logger {
+  emergency: LogFunction;
+  alert: LogFunction;
+  critical: LogFunction;
+  error: LogFunction;
+  warning: LogFunction;
+  notice: LogFunction;
+  info: LogFunction;
+  debug: LogFunction;
+}
+
+export type LogFunction = (message: string, data?: any) => void;
+
+export enum LogLevel {
+  EMERG,
+  ALERT,
+  CRIT,
+  ERROR,
+  WARN,
+  NOTICE,
+  INFO,
+  DEBUG,
+}
+
+export const LOG_LEVEL_STRINGS = [
+  'EMERGENCY',
+  'ALERT',
+  'CRITICAL',
+  'ERROR',
+  'WARN',
+  'NOTICE',
+  'INFO',
+  'DEBUG',
+];
+
+export const LOG_LEVEL_DICTIONARY: Dictionary<LogLevel> = {
+  EMERG: LogLevel.EMERG,
+  EMERGENCY: LogLevel.EMERG,
+  ALERT: LogLevel.ALERT,
+  CRIT: LogLevel.CRIT,
+  CRITICAL: LogLevel.CRIT,
+  ERR: LogLevel.ERROR,
+  ERROR: LogLevel.ERROR,
+  WARN: LogLevel.WARN,
+  WARNING: LogLevel.WARN,
+  NOTICE: LogLevel.NOTICE,
+  INFO: LogLevel.INFO,
+  INFORMATION: LogLevel.INFO,
+  INFORMATIONAL: LogLevel.INFO,
+  DEBUG: LogLevel.DEBUG,
+};

--- a/test/util/environment-editor.ts
+++ b/test/util/environment-editor.ts
@@ -1,0 +1,45 @@
+import { Dictionary } from '../../src/util/interfaces';
+
+export class EnvironmentEditor {
+  private readonly envCopy: Dictionary<string> = {};
+  private readonly envKeys: Dictionary<boolean> = {};
+
+  get(key: string): string | undefined {
+    return process.env[key];
+  }
+
+  set(key: string, value: string) {
+    this.storeOriginalValue(key);
+    process.env[key] = value;
+  }
+
+  clear(key: string) {
+    this.storeOriginalValue(key);
+    delete process.env[key];
+  }
+
+  resetAll() {
+    Object.keys(this.envKeys).forEach(k => {
+      this.reset(k);
+    });
+  }
+
+  reset(key: string): void {
+    if (this.envCopy[key] != null) {
+      process.env[key] = this.envCopy[key];
+      delete this.envCopy[key];
+    } else {
+      delete process.env[key];
+    }
+    delete this.envKeys[key];
+  }
+
+  private storeOriginalValue(key: string) {
+    if (!this.envKeys[key]) {
+      this.envKeys[key] = true;
+      if (process.env[key] != null) {
+        this.envCopy[key] = process.env[key] || '';
+      }
+    }
+  }
+}

--- a/test/util/expect-functions.ts
+++ b/test/util/expect-functions.ts
@@ -1,0 +1,61 @@
+function getTimestamp(time: string | number | Date) {
+  if (typeof time === 'number') {
+    return time;
+  }
+
+  return new Date(time).getTime();
+}
+
+function customExpectCondition(isSuccessful: boolean, failureMessage: string) {
+  if (!isSuccessful) {
+    fail(failureMessage);
+  }
+  return true;
+}
+
+export function expectDate(time: string | number | Date) {
+  const toBeBefore = (afterTime: string | number | Date) =>
+    customExpectCondition(
+      getTimestamp(time) <= getTimestamp(afterTime),
+      `Expected ${time} to be on or before ${afterTime}`
+    );
+  const toBeAfter = (beforeTime: string | number | Date) =>
+    customExpectCondition(
+      getTimestamp(time) >= getTimestamp(beforeTime),
+      `Expected ${time} to be on or after ${beforeTime}`
+    );
+  const toBeBetween = (
+    beforeTime: string | number | Date,
+    afterTime: string | number | Date
+  ) =>
+    customExpectCondition(
+      toBeBefore(afterTime) && toBeAfter(beforeTime),
+      `Expected ${time} to be between ${beforeTime} and ${afterTime}`
+    );
+  return { toBeBefore, toBeAfter, toBeBetween };
+}
+
+export function expectString(str: string) {
+  return {
+    toStartWith: (substring: string) =>
+      customExpectCondition(
+        str.indexOf(substring) === 0,
+        `Expected '${str}' to start with '${substring}'`
+      ),
+    toContain: (substring: string) =>
+      customExpectCondition(
+        str.indexOf(substring) >= 0,
+        `Expected '${str}' to start contain '${substring}'`
+      ),
+    toEndWith: (substring: string) =>
+      customExpectCondition(
+        str.lastIndexOf(substring) === str.length - substring.length,
+        `Expected '${str}' to end with '${substring}'`
+      ),
+    toMatchRegex: (regex: RegExp) =>
+      customExpectCondition(
+        !!str.match(regex),
+        `Expected '${str}' to match ${regex}`
+      ),
+  };
+}

--- a/test/util/index.ts
+++ b/test/util/index.ts
@@ -1,0 +1,2 @@
+export * from './environment-editor';
+export * from './expect-functions';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,15 @@
 {
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "build"
+    "outDir": "dist",
+    "baseUrl": "/",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "declaration": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"],
-  "exclude": ["node_modules", "build"]
+  "include": ["src/*.ts", "src/**/*.ts"],
+  "exclude": ["src/*.spec.ts", "src/**/*.spec.ts", "test/*"]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "sourceMap": false
   },
-  "exclude": ["node_modules", "build", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts", "test"]
 }


### PR DESCRIPTION
Lots of things I wanted to add. I was going to just keep them in my version, but you wanted a PR: 
- Wrapper for logging Bash scripts instead of potentially dangerous npm scripts (Can not be run with `npm config set ignore-scripts true`)
- Use of `main.ts` as main class and `run.ts` as entry point for improved test coverage.
- Use of dist folder for builds, since this is the standard.
--


